### PR TITLE
Fix code scanning alert #46: Double escaping or unescaping

### DIFF
--- a/res/COM_MAIN.js
+++ b/res/COM_MAIN.js
@@ -200,8 +200,8 @@ function COM()
     .replace(/&quot;/g, '"')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&')
-    .replace(/&nbsp;/g, '\u00A0');
+    .replace(/&nbsp;/g, '\u00A0')
+    .replace(/&amp;/g, '&');
   }
 
   this.uuid = function()  // UUID v4


### PR DESCRIPTION
Fixes [https://github.com/RetroAppleJS/RetroAppleJS.github.io/security/code-scanning/46](https://github.com/RetroAppleJS/RetroAppleJS.github.io/security/code-scanning/46)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
