### PR TITLE
Fix Apple II debugger symbol lookup

### DIFF
--- a/res/EMU_apple2debug.js
+++ b/res/EMU_apple2debug.js
@@ -40,6 +40,13 @@ function Apple2Debug()
         {            
             // TODO SEARCH THROUGH watchparam
             var opd = parseInt(op.substring(1,op.length),16)
+            var symlink = null;
+
+            if(typeof(oASM)!="undefined" && oASM && oASM.symlink)
+                symlink = oASM.symlink;
+            else if(typeof(asm)!="undefined" && asm && asm.symlink)
+                symlink = asm.symlink;
+
             switch(adm)
             {
                 case "zpg":
@@ -47,10 +54,13 @@ function Apple2Debug()
                 case "rel":
                 case "iny":
                 case "inx":
-                    var adr = asm.symlink[opd];  // watch parameter translation
-                    if(typeof(adr)!="undefined") return adr+" <small>"+op+"h</small>"
-                    var adr = asm.symlink[opd-1];  // watch parameter translation of address - 1
-                    if(typeof(adr)!="undefined") return adr+"+1 <small>"+op+"h</small>"
+                    if(symlink)
+                    {
+                        var adr = symlink[opd];  // watch parameter translation
+                        if(typeof(adr)!="undefined") return adr+" <small>"+op+"h</small>"
+                        var adr = symlink[opd-1];  // watch parameter translation of address - 1
+                        if(typeof(adr)!="undefined") return adr+"+1 <small>"+op+"h</small>"
+                    }
                 break;
             }
             return op;


### PR DESCRIPTION
Restores the emulator debugger play/scrollFeed path by removing the hard dependency on the legacy global `asm` object.

What changed:
- `EMU_apple2debug.js` now resolves symbols from `oASM.symlink` when available.
- It falls back to the older `asm.symlink` object if present.
- If no symbol table exists yet, disassembly still continues and returns the original operand instead of throwing `can't find variable asm`.

This keeps the debugger usable from the emulator tab even when the assembler tab has not created the old `asm` global.